### PR TITLE
feat: 장바구니 메뉴 옵션 엔티티 분리 후 장바구니 생성, 업데이트, 주문에 적용

### DIFF
--- a/src/main/java/com/caffeine/gwanghwamun/domain/cart/controller/CartController.java
+++ b/src/main/java/com/caffeine/gwanghwamun/domain/cart/controller/CartController.java
@@ -4,10 +4,7 @@ import com.caffeine.gwanghwamun.common.response.ApiResponse;
 import com.caffeine.gwanghwamun.common.response.ResponseUtil;
 import com.caffeine.gwanghwamun.common.security.model.UserDetailsImpl;
 import com.caffeine.gwanghwamun.common.success.SuccessCode;
-import com.caffeine.gwanghwamun.domain.cart.dto.CartResDTO;
-import com.caffeine.gwanghwamun.domain.cart.dto.SaveCartReqDTO;
-import com.caffeine.gwanghwamun.domain.cart.dto.SaveCartResDTO;
-import com.caffeine.gwanghwamun.domain.cart.dto.UpdateCartReqDTO;
+import com.caffeine.gwanghwamun.domain.cart.dto.*;
 import com.caffeine.gwanghwamun.domain.cart.service.CartService;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
@@ -48,12 +45,12 @@ public class CartController {
 	@PreAuthorize("hasRole('CUSTOMER')")
 	@Operation(summary = "장바구니 항목 수정", description = "장바구니에 담긴 메뉴의 옵션과 수량을 수정한다.")
 	@PutMapping("/{cartId}")
-	public ResponseEntity<ApiResponse<CartResDTO>> updateCart(
+	public ResponseEntity<ApiResponse<CartUpdateResDTO>> updateCart(
 			@PathVariable("cartId") UUID cartId,
 			@RequestBody UpdateCartReqDTO cartUpdateReqDTO,
 			@AuthenticationPrincipal UserDetailsImpl user) {
 
-		CartResDTO updatedCart = cartService.updateCart(user.getUser(), cartId, cartUpdateReqDTO);
+		CartUpdateResDTO updatedCart = cartService.updateCart(user.getUser(), cartId, cartUpdateReqDTO);
 		return ResponseUtil.successResponse(SuccessCode.CART_UPDATE_SUCCESS, updatedCart);
 	}
 

--- a/src/main/java/com/caffeine/gwanghwamun/domain/cart/dto/CartItemOptionResDTO.java
+++ b/src/main/java/com/caffeine/gwanghwamun/domain/cart/dto/CartItemOptionResDTO.java
@@ -1,0 +1,5 @@
+package com.caffeine.gwanghwamun.domain.cart.dto;
+
+import java.util.UUID;
+
+public record CartItemOptionResDTO(UUID menuOptionId) {}

--- a/src/main/java/com/caffeine/gwanghwamun/domain/cart/dto/CartResDTO.java
+++ b/src/main/java/com/caffeine/gwanghwamun/domain/cart/dto/CartResDTO.java
@@ -3,15 +3,13 @@ package com.caffeine.gwanghwamun.domain.cart.dto;
 import com.caffeine.gwanghwamun.domain.cart.entity.Cart;
 import java.util.UUID;
 
-public record CartResDTO(
-		UUID cartId, Long userId, UUID storeId, UUID menuId, UUID menuOptionId, Integer quantity) {
+public record CartResDTO(UUID cartId, Long userId, UUID storeId, UUID menuId, Integer quantity) {
 	public CartResDTO(Cart cart) {
 		this(
 				cart.getCartId(),
 				cart.getUser().getUserId(),
 				cart.getStore().getStoreId(),
 				cart.getMenu().getMenuId(),
-				cart.getMenuOption() != null ? cart.getMenuOption().getMenuOptionId() : null,
 				cart.getQuantity());
 	}
 }

--- a/src/main/java/com/caffeine/gwanghwamun/domain/cart/dto/CartUpdateResDTO.java
+++ b/src/main/java/com/caffeine/gwanghwamun/domain/cart/dto/CartUpdateResDTO.java
@@ -1,7 +1,6 @@
 package com.caffeine.gwanghwamun.domain.cart.dto;
 
 import com.caffeine.gwanghwamun.domain.cart.entity.Cart;
-import com.caffeine.gwanghwamun.domain.cart.entity.CartItemOption;
 import java.util.List;
 import java.util.UUID;
 
@@ -10,9 +9,9 @@ public record CartUpdateResDTO(
 		Long userId,
 		UUID storeId,
 		UUID menuId,
-		List<CartItemOption> cartItemOptionList,
+		List<CartItemOptionResDTO> cartItemOptionList,
 		Integer quantity) {
-	public CartUpdateResDTO(Cart cart, List<CartItemOption> cartItemOptionList) {
+	public CartUpdateResDTO(Cart cart, List<CartItemOptionResDTO> cartItemOptionList) {
 		this(
 				cart.getCartId(),
 				cart.getUser().getUserId(),

--- a/src/main/java/com/caffeine/gwanghwamun/domain/cart/dto/CartUpdateResDTO.java
+++ b/src/main/java/com/caffeine/gwanghwamun/domain/cart/dto/CartUpdateResDTO.java
@@ -2,28 +2,23 @@ package com.caffeine.gwanghwamun.domain.cart.dto;
 
 import com.caffeine.gwanghwamun.domain.cart.entity.Cart;
 import com.caffeine.gwanghwamun.domain.cart.entity.CartItemOption;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
-public record SaveCartResDTO(
+public record CartUpdateResDTO(
 		UUID cartId,
 		Long userId,
 		UUID storeId,
 		UUID menuId,
 		List<CartItemOption> cartItemOptionList,
-		Integer quantity,
-		LocalDateTime createdAt,
-		LocalDateTime updatedAt) {
-	public SaveCartResDTO(Cart cart, List<CartItemOption> cartItemOptionList) {
+		Integer quantity) {
+	public CartUpdateResDTO(Cart cart, List<CartItemOption> cartItemOptionList) {
 		this(
 				cart.getCartId(),
 				cart.getUser().getUserId(),
 				cart.getStore().getStoreId(),
 				cart.getMenu().getMenuId(),
 				cartItemOptionList,
-				cart.getQuantity(),
-				cart.getCreateAt(),
-				cart.getLastUpdatedAt());
+				cart.getQuantity());
 	}
 }

--- a/src/main/java/com/caffeine/gwanghwamun/domain/cart/dto/SaveCartReqDTO.java
+++ b/src/main/java/com/caffeine/gwanghwamun/domain/cart/dto/SaveCartReqDTO.java
@@ -1,6 +1,5 @@
 package com.caffeine.gwanghwamun.domain.cart.dto;
 
-import com.caffeine.gwanghwamun.domain.cart.entity.CartMode;
 import jakarta.validation.constraints.Min;
 import java.util.List;
 import java.util.UUID;
@@ -9,5 +8,4 @@ public record SaveCartReqDTO(
 		UUID storeId,
 		UUID menuId,
 		List<UUID> menuOptionIdList,
-		@Min(value = 0, message = "수량은 0 이상이어야 합니다.") Integer quantity,
-		CartMode cartMode) {}
+		@Min(value = 0, message = "수량은 0 이상이어야 합니다.") Integer quantity) {}

--- a/src/main/java/com/caffeine/gwanghwamun/domain/cart/dto/SaveCartReqDTO.java
+++ b/src/main/java/com/caffeine/gwanghwamun/domain/cart/dto/SaveCartReqDTO.java
@@ -2,11 +2,12 @@ package com.caffeine.gwanghwamun.domain.cart.dto;
 
 import com.caffeine.gwanghwamun.domain.cart.entity.CartMode;
 import jakarta.validation.constraints.Min;
+import java.util.List;
 import java.util.UUID;
 
 public record SaveCartReqDTO(
 		UUID storeId,
 		UUID menuId,
-		UUID menuOptionId,
+		List<UUID> menuOptionIdList,
 		@Min(value = 0, message = "수량은 0 이상이어야 합니다.") Integer quantity,
 		CartMode cartMode) {}

--- a/src/main/java/com/caffeine/gwanghwamun/domain/cart/dto/SaveCartResDTO.java
+++ b/src/main/java/com/caffeine/gwanghwamun/domain/cart/dto/SaveCartResDTO.java
@@ -1,7 +1,6 @@
 package com.caffeine.gwanghwamun.domain.cart.dto;
 
 import com.caffeine.gwanghwamun.domain.cart.entity.Cart;
-import com.caffeine.gwanghwamun.domain.cart.entity.CartItemOption;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -11,11 +10,11 @@ public record SaveCartResDTO(
 		Long userId,
 		UUID storeId,
 		UUID menuId,
-		List<CartItemOption> cartItemOptionList,
+		List<CartItemOptionResDTO> cartItemOptionList,
 		Integer quantity,
 		LocalDateTime createdAt,
 		LocalDateTime updatedAt) {
-	public SaveCartResDTO(Cart cart, List<CartItemOption> cartItemOptionList) {
+	public SaveCartResDTO(Cart cart, List<CartItemOptionResDTO> cartItemOptionList) {
 		this(
 				cart.getCartId(),
 				cart.getUser().getUserId(),

--- a/src/main/java/com/caffeine/gwanghwamun/domain/cart/dto/UpdateCartReqDTO.java
+++ b/src/main/java/com/caffeine/gwanghwamun/domain/cart/dto/UpdateCartReqDTO.java
@@ -1,7 +1,8 @@
 package com.caffeine.gwanghwamun.domain.cart.dto;
 
 import jakarta.validation.constraints.Min;
+import java.util.List;
 import java.util.UUID;
 
 public record UpdateCartReqDTO(
-		UUID menuOptionId, @Min(value = 0, message = "수량은 0 이상이어야 합니다.") int quantity) {}
+		List<UUID> menuOptionIdList, @Min(value = 0, message = "수량은 0 이상이어야 합니다.") int quantity) {}

--- a/src/main/java/com/caffeine/gwanghwamun/domain/cart/entity/Cart.java
+++ b/src/main/java/com/caffeine/gwanghwamun/domain/cart/entity/Cart.java
@@ -45,18 +45,13 @@ public class Cart extends BaseEntity {
 	@Column(name = "total_price", nullable = false)
 	private int totalPrice;
 
-	@Enumerated(EnumType.STRING)
-	private CartMode cartMode;
-
 	@Builder
-	public Cart(
-			User user, Store store, Menu menu, int quantity, CartMode cartMode, Integer totalPrice) {
+	public Cart(User user, Store store, Menu menu, int quantity, Integer totalPrice) {
 		this.user = user;
 		this.store = store;
 		this.menu = menu;
 		this.quantity = quantity;
 		this.totalPrice = totalPrice;
-		this.cartMode = cartMode;
 	}
 
 	public void updateQuantity(int quantity) {

--- a/src/main/java/com/caffeine/gwanghwamun/domain/cart/entity/Cart.java
+++ b/src/main/java/com/caffeine/gwanghwamun/domain/cart/entity/Cart.java
@@ -2,7 +2,6 @@ package com.caffeine.gwanghwamun.domain.cart.entity;
 
 import com.caffeine.gwanghwamun.domain.BaseEntity;
 import com.caffeine.gwanghwamun.domain.menu.entity.Menu;
-import com.caffeine.gwanghwamun.domain.menu.entity.MenuOption;
 import com.caffeine.gwanghwamun.domain.store.entity.Store;
 import com.caffeine.gwanghwamun.domain.user.entity.User;
 import jakarta.persistence.*;
@@ -40,10 +39,6 @@ public class Cart extends BaseEntity {
 
 	private String deletedBy;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "menu_option_id")
-	private MenuOption menuOption;
-
 	@Column(name = "quantity", nullable = false)
 	private int quantity;
 
@@ -55,24 +50,17 @@ public class Cart extends BaseEntity {
 
 	@Builder
 	public Cart(
-			User user, Store store, Menu menu, MenuOption menuOption, int quantity, CartMode cartMode) {
+			User user, Store store, Menu menu, int quantity, CartMode cartMode, Integer totalPrice) {
 		this.user = user;
 		this.store = store;
 		this.menu = menu;
-		this.menuOption = menuOption;
 		this.quantity = quantity;
-		this.totalPrice = calculateTotalPrice(menu, menuOption, quantity);
+		this.totalPrice = totalPrice;
 		this.cartMode = cartMode;
 	}
 
 	public void updateQuantity(int quantity) {
 		this.quantity = quantity;
-		this.totalPrice = calculateTotalPrice(menu, menuOption, quantity);
-	}
-
-	public void updateMenuOption(MenuOption option) {
-		this.menuOption = option;
-		this.totalPrice = calculateTotalPrice(menu, menuOption, quantity);
 	}
 
 	public void delete(User user) {
@@ -80,9 +68,7 @@ public class Cart extends BaseEntity {
 		this.deletedBy = user.getName();
 	}
 
-	private int calculateTotalPrice(Menu menu, MenuOption option, int quantity) {
-		return menuOption == null
-				? quantity * menu.getPrice()
-				: quantity * (menu.getPrice() + menuOption.getPrice());
+	public void updateTotalPrice(Integer totalPrice) {
+		this.totalPrice = totalPrice;
 	}
 }

--- a/src/main/java/com/caffeine/gwanghwamun/domain/cart/entity/CartItemOption.java
+++ b/src/main/java/com/caffeine/gwanghwamun/domain/cart/entity/CartItemOption.java
@@ -1,3 +1,42 @@
 package com.caffeine.gwanghwamun.domain.cart.entity;
 
-public class CartItemOption {}
+import com.caffeine.gwanghwamun.domain.menu.entity.MenuOption;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "p_cart_item_option")
+@NoArgsConstructor
+public class CartItemOption {
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	@Column(name = "cart_item_option_id", nullable = false)
+	private UUID orderItemOptionId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "menu_option_id", nullable = false)
+	private MenuOption menuOption;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "cart_id", nullable = false)
+	private Cart cart;
+
+	@Column(name = "deleted_date", nullable = true)
+	private LocalDateTime deletedDate;
+
+	@Column(name = "deleted_by", nullable = true)
+	private String deletedBy;
+
+	@Builder
+	public CartItemOption(MenuOption menuOption, Cart cart) {
+		this.cart = cart;
+		this.menuOption = menuOption;
+	}
+}

--- a/src/main/java/com/caffeine/gwanghwamun/domain/cart/entity/CartMode.java
+++ b/src/main/java/com/caffeine/gwanghwamun/domain/cart/entity/CartMode.java
@@ -1,6 +1,0 @@
-package com.caffeine.gwanghwamun.domain.cart.entity;
-
-public enum CartMode {
-	DIRECT,
-	CART
-}

--- a/src/main/java/com/caffeine/gwanghwamun/domain/cart/repository/CartItemOptionRepository.java
+++ b/src/main/java/com/caffeine/gwanghwamun/domain/cart/repository/CartItemOptionRepository.java
@@ -1,0 +1,14 @@
+package com.caffeine.gwanghwamun.domain.cart.repository;
+
+import com.caffeine.gwanghwamun.domain.cart.entity.Cart;
+import com.caffeine.gwanghwamun.domain.cart.entity.CartItemOption;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CartItemOptionRepository extends JpaRepository<CartItemOption, UUID> {
+
+	List<CartItemOption> findAllByCartAndDeletedDateIsNull(Cart cart);
+
+	void deleteAllByCart(Cart cart);
+}

--- a/src/main/java/com/caffeine/gwanghwamun/domain/cart/service/CartService.java
+++ b/src/main/java/com/caffeine/gwanghwamun/domain/cart/service/CartService.java
@@ -2,11 +2,10 @@ package com.caffeine.gwanghwamun.domain.cart.service;
 
 import com.caffeine.gwanghwamun.common.exception.CustomException;
 import com.caffeine.gwanghwamun.common.exception.ErrorCode;
-import com.caffeine.gwanghwamun.domain.cart.dto.CartResDTO;
-import com.caffeine.gwanghwamun.domain.cart.dto.SaveCartReqDTO;
-import com.caffeine.gwanghwamun.domain.cart.dto.SaveCartResDTO;
-import com.caffeine.gwanghwamun.domain.cart.dto.UpdateCartReqDTO;
+import com.caffeine.gwanghwamun.domain.cart.dto.*;
 import com.caffeine.gwanghwamun.domain.cart.entity.Cart;
+import com.caffeine.gwanghwamun.domain.cart.entity.CartItemOption;
+import com.caffeine.gwanghwamun.domain.cart.repository.CartItemOptionRepository;
 import com.caffeine.gwanghwamun.domain.cart.repository.CartRepository;
 import com.caffeine.gwanghwamun.domain.menu.entity.Menu;
 import com.caffeine.gwanghwamun.domain.menu.entity.MenuOption;
@@ -32,54 +31,64 @@ public class CartService {
 	private final StoreRepository storeRepository;
 	private final MenuRepository menuRepository;
 	private final MenuOptionRepository menuOptionRepository;
+	private final CartItemOptionRepository cartItemOptionRepository;
 
 	@Transactional
 	public SaveCartResDTO saveCart(Long userId, SaveCartReqDTO req) {
-
-		Store store =
-				storeRepository
-						.findById(req.storeId())
-						.orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
-
-		Menu menu =
-				menuRepository
-						.findById(req.menuId())
-						.orElseThrow(() -> new CustomException(ErrorCode.MENU_NOT_FOUND));
-
-		MenuOption option = null;
-		if (req.menuOptionId() != null) {
-			option =
-					menuOptionRepository
-							.findById(req.menuOptionId())
-							.orElseThrow(() -> new CustomException(ErrorCode.MENU_OPTION_NOT_FOUND));
-		}
 
 		User user =
 				userRepository
 						.findById(userId)
 						.orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
+		Store store =
+				storeRepository
+						.findActiveById(req.storeId())
+						.orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
+
+		Menu menu =
+				menuRepository
+						.findByIdAndNotDeleted(req.menuId())
+						.orElseThrow(() -> new CustomException(ErrorCode.MENU_NOT_FOUND));
+
 		if (menu.isSoldOut() || menu.isHidden()) {
 			throw new CustomException(ErrorCode.ORDER_UNABLE_MENU);
 		}
 
-		if (option != null && (option.isSoldOut() || option.isHidden())) {
-			throw new CustomException(ErrorCode.ORDER_UNABLE_MENU_OPTION);
+		List<MenuOption> menuOptions =
+				menuOptionRepository.findAllByMenuOptionIdInAndMenuId(
+						req.menuOptionIdList(), menu.getMenuId());
+
+		for (MenuOption option : menuOptions) {
+			if (option.isSoldOut() || option.isHidden()) {
+				throw new CustomException(ErrorCode.ORDER_UNABLE_MENU_OPTION);
+			}
 		}
+
+		int optionPrice = menuOptions.stream().mapToInt(MenuOption::getPrice).sum();
+
+		int itemTotalPrice = (menu.getPrice() + optionPrice) * req.quantity();
 
 		Cart cart =
 				Cart.builder()
 						.user(user)
 						.store(store)
 						.menu(menu)
-						.menuOption(option)
 						.quantity(req.quantity())
 						.cartMode(req.cartMode())
+						.totalPrice(itemTotalPrice)
 						.build();
 
 		cartRepository.save(cart);
 
-		return new SaveCartResDTO(cart);
+		List<CartItemOption> cartItemOptions =
+				menuOptions.stream()
+						.map(option -> CartItemOption.builder().menuOption(option).cart(cart).build())
+						.toList();
+
+		cartItemOptionRepository.saveAll(cartItemOptions);
+
+		return new SaveCartResDTO(cart, cartItemOptions);
 	}
 
 	@Transactional
@@ -89,7 +98,7 @@ public class CartService {
 	}
 
 	@Transactional
-	public CartResDTO updateCart(User user, UUID cartId, UpdateCartReqDTO req) {
+	public CartUpdateResDTO updateCart(User user, UUID cartId, UpdateCartReqDTO req) {
 		Cart cart =
 				cartRepository
 						.findById(cartId)
@@ -101,20 +110,37 @@ public class CartService {
 
 		cart.updateQuantity(req.quantity());
 
-		if (req.menuOptionId() != null) {
-			MenuOption option =
-					menuOptionRepository
-							.findById(req.menuOptionId())
-							.orElseThrow(() -> new CustomException(ErrorCode.MENU_OPTION_NOT_FOUND));
+		int optionPrice = 0;
 
-			if (option != null && (option.isSoldOut() || option.isHidden())) {
-				throw new CustomException(ErrorCode.ORDER_UNABLE_MENU_OPTION);
+		List<CartItemOption> cartItemOptionList = null;
+
+		if (req.menuOptionIdList() != null && !req.menuOptionIdList().isEmpty()) {
+			List<MenuOption> menuOptions =
+					menuOptionRepository.findAllByMenuOptionIdInAndMenuId(
+							req.menuOptionIdList(), cart.getMenu().getMenuId());
+
+			for (MenuOption option : menuOptions) {
+				if (option.isSoldOut() || option.isHidden()) {
+					throw new CustomException(ErrorCode.ORDER_UNABLE_MENU_OPTION);
+				}
 			}
 
-			cart.updateMenuOption(option);
+			optionPrice = menuOptions.stream().mapToInt(MenuOption::getPrice).sum();
+
+			cartItemOptionRepository.deleteAllByCart(cart);
+			cartItemOptionList =
+					menuOptions.stream()
+							.map(opt -> CartItemOption.builder().cart(cart).menuOption(opt).build())
+							.toList();
+
+			cartItemOptionRepository.saveAll(cartItemOptionList);
 		}
 
-		return new CartResDTO(cart);
+		int totalPrice = (cart.getMenu().getPrice() + optionPrice) * cart.getQuantity();
+
+		cart.updateTotalPrice(totalPrice);
+
+		return new CartUpdateResDTO(cart, cartItemOptionList);
 	}
 
 	@Transactional

--- a/src/main/java/com/caffeine/gwanghwamun/domain/cart/service/CartService.java
+++ b/src/main/java/com/caffeine/gwanghwamun/domain/cart/service/CartService.java
@@ -84,10 +84,14 @@ public class CartService {
 				menuOptions.stream()
 						.map(option -> CartItemOption.builder().menuOption(option).cart(cart).build())
 						.toList();
+		List<CartItemOptionResDTO> cartItemOptionResList =
+				cartItemOptions.stream()
+						.map(opt -> new CartItemOptionResDTO(opt.getMenuOption().getMenuOptionId()))
+						.toList();
 
 		cartItemOptionRepository.saveAll(cartItemOptions);
 
-		return new SaveCartResDTO(cart, cartItemOptions);
+		return new SaveCartResDTO(cart, cartItemOptionResList);
 	}
 
 	@Transactional
@@ -134,12 +138,16 @@ public class CartService {
 
 			cartItemOptionRepository.saveAll(cartItemOptionList);
 		}
+		List<CartItemOptionResDTO> cartItemOptionResList =
+				cartItemOptionList.stream()
+						.map(opt -> new CartItemOptionResDTO(opt.getMenuOption().getMenuOptionId()))
+						.toList();
 
 		int totalPrice = (cart.getMenu().getPrice() + optionPrice) * cart.getQuantity();
 
 		cart.updateTotalPrice(totalPrice);
 
-		return new CartUpdateResDTO(cart, cartItemOptionList);
+		return new CartUpdateResDTO(cart, cartItemOptionResList);
 	}
 
 	@Transactional

--- a/src/main/java/com/caffeine/gwanghwamun/domain/cart/service/CartService.java
+++ b/src/main/java/com/caffeine/gwanghwamun/domain/cart/service/CartService.java
@@ -75,7 +75,6 @@ public class CartService {
 						.store(store)
 						.menu(menu)
 						.quantity(req.quantity())
-						.cartMode(req.cartMode())
 						.totalPrice(itemTotalPrice)
 						.build();
 

--- a/src/main/java/com/caffeine/gwanghwamun/domain/order/dto/SaveOrderReqDTO.java
+++ b/src/main/java/com/caffeine/gwanghwamun/domain/order/dto/SaveOrderReqDTO.java
@@ -6,9 +6,9 @@ import java.util.UUID;
 
 public record SaveOrderReqDTO(
 		UUID storeId,
+		CartMode cartMode,
 		List<OrderMenuItemReqDTO> menuItemList,
 		String address,
 		Object paymentMethod,
-		CartMode cartMode,
 		String deliveryContent,
 		String requests) {}

--- a/src/main/java/com/caffeine/gwanghwamun/domain/order/dto/SaveOrderReqDTO.java
+++ b/src/main/java/com/caffeine/gwanghwamun/domain/order/dto/SaveOrderReqDTO.java
@@ -1,6 +1,6 @@
 package com.caffeine.gwanghwamun.domain.order.dto;
 
-import com.caffeine.gwanghwamun.domain.cart.entity.CartMode;
+import com.caffeine.gwanghwamun.domain.order.entity.CartMode;
 import java.util.List;
 import java.util.UUID;
 

--- a/src/main/java/com/caffeine/gwanghwamun/domain/order/entity/CartMode.java
+++ b/src/main/java/com/caffeine/gwanghwamun/domain/order/entity/CartMode.java
@@ -1,0 +1,6 @@
+package com.caffeine.gwanghwamun.domain.order.entity;
+
+public enum CartMode {
+	DIRECT,
+	CART
+}

--- a/src/main/java/com/caffeine/gwanghwamun/domain/order/entity/Order.java
+++ b/src/main/java/com/caffeine/gwanghwamun/domain/order/entity/Order.java
@@ -40,6 +40,10 @@ public class Order extends BaseEntity {
 	@Column(name = "delivery_content", nullable = true)
 	private String deliveryContent;
 
+	@Column(name = "mode", nullable = false)
+	@Enumerated(EnumType.STRING)
+	private CartMode mode;
+
 	@Column(name = "deleted_date", nullable = true)
 	private LocalDateTime deletedDate;
 
@@ -66,12 +70,14 @@ public class Order extends BaseEntity {
 			int totalPrice,
 			String deliveryAddress,
 			String deliveryContent,
-			String requests) {
+			String requests,
+			CartMode mode) {
 		this.store = store;
 		this.user = user;
 		this.orderStatus = orderStatus;
 		this.totalPrice = totalPrice;
 		this.requests = requests;
+		this.mode = mode;
 		this.deliveryAddress = deliveryAddress;
 		this.deliveryContent = deliveryContent;
 	}

--- a/src/main/java/com/caffeine/gwanghwamun/domain/order/service/OrderItemService.java
+++ b/src/main/java/com/caffeine/gwanghwamun/domain/order/service/OrderItemService.java
@@ -2,6 +2,8 @@ package com.caffeine.gwanghwamun.domain.order.service;
 
 import com.caffeine.gwanghwamun.common.exception.CustomException;
 import com.caffeine.gwanghwamun.common.exception.ErrorCode;
+import com.caffeine.gwanghwamun.domain.cart.entity.Cart;
+import com.caffeine.gwanghwamun.domain.cart.repository.CartItemOptionRepository;
 import com.caffeine.gwanghwamun.domain.menu.entity.Menu;
 import com.caffeine.gwanghwamun.domain.menu.entity.MenuOption;
 import com.caffeine.gwanghwamun.domain.menu.repository.MenuOptionRepository;
@@ -16,6 +18,7 @@ import com.caffeine.gwanghwamun.domain.order.repository.OrderItemRepository;
 import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -27,6 +30,7 @@ public class OrderItemService {
 	private final OrderItemOptionRepository orderItemOptionRepository;
 	private final MenuRepository menuRepository;
 	private final MenuOptionRepository menuOptionRepository;
+	private final CartItemOptionRepository cartItemOptionRepository;
 
 	@Transactional
 	public List<OrderItemListResDTO> saveOrderItem(List<OrderMenuItemReqDTO> menuList, Order order) {
@@ -85,5 +89,24 @@ public class OrderItemService {
 			orderItemInfoList.add(new OrderItemListResDTO(orderItem, orderItemOptions, itemTotalPrice));
 		}
 		return orderItemInfoList;
+	}
+
+	@Transactional
+	public List<OrderItemListResDTO> saveOrderFromCart(List<Cart> cartList, Order order) {
+
+		List<OrderMenuItemReqDTO> menuItemList =
+				cartList.stream()
+						.map(
+								cart -> {
+									List<UUID> menuOptionIds =
+											cartItemOptionRepository.findAllByCartAndDeletedDateIsNull(cart).stream()
+													.map(option -> option.getMenuOption().getMenuOptionId())
+													.toList();
+
+									return new OrderMenuItemReqDTO(cart.getMenu(), menuOptionIds, cart.getQuantity());
+								})
+						.toList();
+
+		return saveOrderItem(menuItemList, order);
 	}
 }

--- a/src/main/java/com/caffeine/gwanghwamun/domain/order/service/OrderService.java
+++ b/src/main/java/com/caffeine/gwanghwamun/domain/order/service/OrderService.java
@@ -2,6 +2,8 @@ package com.caffeine.gwanghwamun.domain.order.service;
 
 import com.caffeine.gwanghwamun.common.exception.CustomException;
 import com.caffeine.gwanghwamun.common.exception.ErrorCode;
+import com.caffeine.gwanghwamun.domain.cart.entity.Cart;
+import com.caffeine.gwanghwamun.domain.cart.entity.CartMode;
 import com.caffeine.gwanghwamun.domain.cart.repository.CartRepository;
 import com.caffeine.gwanghwamun.domain.order.dto.*;
 import com.caffeine.gwanghwamun.domain.order.entity.Order;
@@ -93,18 +95,22 @@ public class OrderService {
 
 		orderRepository.save(order);
 
-		//    if (req.cartMode() == CartMode.CART) {
-		//      List<Cart> cartItemList = cartRepository.findByUserAndStoreAndDeletedDateIsNull(user,
-		// store);
-		//      cartItemList.stream().map()
-		//    } else {
-		List<OrderItemListResDTO> orderItemResList =
-				orderItemService.saveOrderItem(req.menuItemList(), order);
-		//    }
+		List<OrderItemListResDTO> orderItemResList;
+		if (req.cartMode() == CartMode.CART) {
+			List<Cart> cartList = cartRepository.findByUserAndStoreAndDeletedDateIsNull(user, store);
+			if (cartList.isEmpty()) {
+				throw new CustomException(ErrorCode.CART_NOT_FOUND);
+			}
+			orderItemResList = orderItemService.saveOrderFromCart(cartList, order);
+		} else {
+			orderItemResList = orderItemService.saveOrderItem(req.menuItemList(), order);
+		}
+
 		totalPrice = orderItemResList.stream().mapToInt(OrderItemListResDTO::totalPrice).sum();
 		if (totalPrice < store.getMinDeliveryPrice()) {
 			throw new CustomException(ErrorCode.LOW_MIN_DELEVERY_PRICE);
 		}
+
 		totalPrice += store.getDeliveryTip();
 		order.updateTotalPrice(totalPrice);
 

--- a/src/main/java/com/caffeine/gwanghwamun/domain/order/service/OrderService.java
+++ b/src/main/java/com/caffeine/gwanghwamun/domain/order/service/OrderService.java
@@ -3,13 +3,9 @@ package com.caffeine.gwanghwamun.domain.order.service;
 import com.caffeine.gwanghwamun.common.exception.CustomException;
 import com.caffeine.gwanghwamun.common.exception.ErrorCode;
 import com.caffeine.gwanghwamun.domain.cart.entity.Cart;
-import com.caffeine.gwanghwamun.domain.cart.entity.CartMode;
 import com.caffeine.gwanghwamun.domain.cart.repository.CartRepository;
 import com.caffeine.gwanghwamun.domain.order.dto.*;
-import com.caffeine.gwanghwamun.domain.order.entity.Order;
-import com.caffeine.gwanghwamun.domain.order.entity.OrderItem;
-import com.caffeine.gwanghwamun.domain.order.entity.OrderStatus;
-import com.caffeine.gwanghwamun.domain.order.entity.OrderStatusLog;
+import com.caffeine.gwanghwamun.domain.order.entity.*;
 import com.caffeine.gwanghwamun.domain.order.repository.OrderItemRepository;
 import com.caffeine.gwanghwamun.domain.order.repository.OrderRepository;
 import com.caffeine.gwanghwamun.domain.order.repository.OrderStatusLogRepository;
@@ -89,6 +85,7 @@ public class OrderService {
 						.orderStatus(OrderStatus.ORDER_WAITING)
 						.deliveryAddress(req.address())
 						.totalPrice(totalPrice)
+						.mode(req.cartMode())
 						.deliveryContent(req.deliveryContent())
 						.requests(req.requests())
 						.build();


### PR DESCRIPTION
🌟개요
---
장바구니 메뉴 옵션 엔티티 분리

🌐연결된 Issues
---
Closes #77 

📋작업사항
---
장바구니 메뉴 옵션 엔티티 분리하여 생성, 업데이트 수정
장바구니모드 선택하여 주문 시 장바구니에 있는 메뉴로 결제

✏️작성한 이슈 외 작업사항
---

✅체크리스트
---
- [ ] PR 규칙을 준수하였는가?
- [ ] 이슈번호를 작성하였는가?
- [ ] 추가/수정 사항을 설명하였는가?
